### PR TITLE
fix: fix container building on mac os

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN npm run build
 
 FROM python:3.11-slim-bookworm
 
-RUN apt-get update -y && apt-get install -y gcc
+RUN apt-get update -y && apt-get install -y gcc && rm -rf /var/lib/apt/lists/*
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,14 @@ RUN npm run build
 
 FROM python:3.11-slim-bookworm
 
+RUN apt-get update -y && apt-get install -y gcc
+
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # Install poetry for packages management
-RUN python -m pip install poetry
+RUN python -m pip install -U pip poetry
 RUN poetry config virtualenvs.create false
 
 # Use /app as the working directory


### PR DESCRIPTION
Launching demo with `docker compose -f docker-compose-local.yaml up` fails on mac os during building the image.

It seems like `psutil` binaries are not available during building of docker image on mac os, and instead it tries to build `psutil` from scratch and crashes with the following error:

```
 => [web stage-1  7/10] COPY --from=build-step /app/dist /app/static                                                                                                         0.0s 
 => ERROR [web stage-1  8/10] RUN poetry install --no-interaction --no-ansi --no-root --without dev                                                                         17.5s 
------
 > [web stage-1  8/10] RUN poetry install --no-interaction --no-ansi --no-root --without dev:
0.431 Skipping virtualenv creation, as specified in config file.
0.502 Installing dependencies from lock file
0.577 
0.577 Package operations: 38 installs, 5 updates, 0 removals
0.578 
0.578   • Installing humanfriendly (10.0)
0.578   • Downgrading idna (3.6 -> 3.4)
0.578   • Installing mpmath (1.3.0)
0.579   • Installing sniffio (1.3.0)
1.497   • Installing anyio (3.7.1)
1.497   • Downgrading certifi (2023.11.17 -> 2023.7.22)
1.497   • Downgrading charset-normalizer (3.3.2 -> 3.3.0)
1.497   • Installing coloredlogs (15.0.1)
1.498   • Installing flatbuffers (23.5.26)
1.499   • Installing h11 (0.14.0)
1.502   • Installing hpack (4.0.0)
1.502   • Installing hyperframe (6.0.1)
1.502   • Installing numpy (1.26.1)
1.504   • Installing protobuf (4.24.4)
1.579   • Installing sympy (1.12)
1.584   • Installing typing-extensions (4.8.0)
1.585   • Downgrading urllib3 (2.1.0 -> 1.26.17)
5.115   • Installing annotated-types (0.6.0)
5.115   • Installing grpcio (1.59.0)
5.115   • Installing h2 (4.1.0)
5.117   • Installing httpcore (0.18.0)
5.117   • Installing onnx (1.14.1)
5.118   • Installing onnxruntime (1.16.1)
5.119   • Installing pydantic-core (2.10.1)
5.120   • Updating setuptools (65.5.1 -> 68.2.2)
5.120   • Installing six (1.16.0)
5.120   • Installing tokenizers (0.13.3)
5.189   • Installing tqdm (4.66.1)
10.79   • Installing click (8.1.7)
10.79   • Installing fastembed (0.1.1)
10.79   • Installing grpcio-tools (1.59.0)
10.79   • Installing httpx (0.25.0)
10.79   • Installing portalocker (2.8.2)
10.79   • Installing pydantic (2.4.2)
10.79   • Installing python-dateutil (2.8.2)
10.79   • Installing pytz (2023.3.post1)
10.79   • Installing starlette (0.27.0)
11.97   • Installing fastapi (0.103.2)
11.97   • Installing loguru (0.5.3)
11.98   • Installing pandas (1.5.3)
11.98   • Installing psutil (5.9.6)
11.98   • Installing qdrant-client (1.6.3)
11.98   • Installing uvicorn (0.18.3)
14.19 
14.19   ChefBuildError
14.19 
14.19   Backend subprocess exited when trying to invoke build_wheel
14.19   
14.19   running bdist_wheel
14.19   running build
14.19   running build_py
14.19   creating build
14.19   creating build/lib.linux-aarch64-cpython-311
14.19   creating build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/_pslinux.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/_common.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/_pssunos.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/_compat.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/_psaix.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/_psosx.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/_psposix.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/_pswindows.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/_psbsd.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   copying psutil/__init__.py -> build/lib.linux-aarch64-cpython-311/psutil
14.19   creating build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_aix.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_system.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_windows.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_process.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_memleaks.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_testutils.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_sunos.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/runner.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_contracts.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_osx.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_connections.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_linux.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/__main__.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_bsd.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_misc.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_unicode.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/__init__.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   copying psutil/tests/test_posix.py -> build/lib.linux-aarch64-cpython-311/psutil/tests
14.19   warning: build_py: byte-compiling is disabled, skipping.
14.19   
14.19   running build_ext
14.19   building 'psutil._psutil_linux' extension
14.19   creating build/temp.linux-aarch64-cpython-311
14.19   creating build/temp.linux-aarch64-cpython-311/psutil
14.19   gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=596 -DPy_LIMITED_API=0x03060000 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -DPSUTIL_LINUX=1 -I/tmp/tmpa0a8r4tk/.venv/include -I/usr/local/include/python3.11 -c psutil/_psutil_common.c -o build/temp.linux-aarch64-cpython-311/psutil/_psutil_common.o
14.19   psutil could not be installed from sources because gcc is not installed. Try running:
14.19     sudo apt-get install gcc python3-dev
14.19   error: command 'gcc' failed: No such file or directory
14.19   
14.19 
14.19   at /usr/local/lib/python3.11/site-packages/poetry/installation/chef.py:164 in _prepare
14.19       160│ 
14.19       161│                 error = ChefBuildError("\n\n".join(message_parts))
14.19       162│ 
14.19       163│             if error is not None:
14.19     → 164│                 raise error from None
14.19       165│ 
14.19       166│             return path
14.19       167│ 
14.19       168│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
14.19 
14.19 Note: This error originates from the build backend, and is likely not a problem with poetry but with psutil (5.9.6) not supporting PEP 517 builds. You can verify this by running 'pip wheel --no-cache-dir --use-pep517 "psutil (==5.9.6)"'.
14.19 
------
failed to solve: process "/bin/sh -c poetry install --no-interaction --no-ansi --no-root --without dev" did not complete successfully: exit code: 1
```

There are probably more efficient and neat solutions to this problem, rather than just installing `gcc`, but I think that there is no much sense in investing time and efforts into them. `gcc` installation increases image size from 706 to 960 MB.