### PR TITLE
ci: update GitHub Actions to Node 24 before June 2 deadline

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Build backend
       run: |
         cd $GITHUB_WORKSPACE

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Build backend
       run: |
         cd $GITHUB_WORKSPACE


### PR DESCRIPTION
## Summary

GitHub will force all JavaScript-based actions to run on Node 24 starting **June 2, 2026**.
Node 20 will be removed from runners entirely on September 16, 2026.

This PR updates all `actions/*` references to the latest Node 24-native versions.

## Changes

| Action | From | To | Node |
|--------|------|----|------|
| actions/checkout | v1-v4 | v6.0.2 | 24 |
| actions/setup-python | v2-v5 | v6.2.0 | 24 |
| actions/setup-node | v2-v4 | v6.4.0 | 24 |
| actions/setup-go | v4-v5 | v6.4.0 | 24 |
| actions/cache | v3-v4 | v5.0.5 | 24 |
| actions/upload-artifact | v4 | v7.0.1 | 24 |
| actions/download-artifact | v4-v5 | v8.0.1 | 24 |

All target SHAs verified against their tags via the GitHub API.
All target versions confirmed running Node 24 in their action.yml.

## References

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/